### PR TITLE
Only export derived keys

### DIFF
--- a/ping/apps/regress.py
+++ b/ping/apps/regress.py
@@ -51,7 +51,7 @@ class PINGDataSession(PINGSession):
 
     def parse_and_display_regression(self, tsv_text, plot=False):
         try:
-            rec = np.recfromcsv(StringIO.StringIO(tsv_text))
+            rec = np.recfromcsv(StringIO(tsv_text))
         except Exception as e:
             raise Exception("Failed to parse data response (%s): %s" % (tsv_text, e))
         else:

--- a/ping/data/__init__.py
+++ b/ping/data/__init__.py
@@ -233,8 +233,10 @@ class PINGData(object):
 
         return self
 
-    def export(self, out_file):
+    def export(self, out_file, partial=True):
         keys = list(self.data_dict.keys())
+        if partial:
+            keys = list(set(keys) - set(self.PING_DATA.keys()))
 
         dir_path = os.path.dirname(out_file)
         if not os.path.exists(dir_path):

--- a/ping/data/__init__.py
+++ b/ping/data/__init__.py
@@ -161,11 +161,12 @@ class PINGData(object):
             csv_path = csv_path or os.path.join('csv', 'PING_raw_data.csv')
 
             # Download data
+            sess = PINGSession(username=username, passwd=passwd)
             if not os.path.exists(csv_path):
                 print("Downloading PING data...")
-                sess = PINGSession(username=username, passwd=passwd)
                 sess.login()
                 sess.download_PING_spreadsheet(out_file=csv_path)
+            sess.clean_PING_spreadsheet(out_file=csv_path)
 
             print("Loading PING data...")
             try:
@@ -237,6 +238,7 @@ class PINGData(object):
         keys = list(self.data_dict.keys())
         if partial:
             keys = list(set(keys) - set(self.PING_DATA.keys()))
+            keys += ['SubjID']
 
         dir_path = os.path.dirname(out_file)
         if not os.path.exists(dir_path):


### PR DESCRIPTION
The "user" database being shared with PING remotely had started containing all PING data--beyond the custom ones. Now there is code to eliminate this duplication and output only derived columns.